### PR TITLE
Correct the path to the readinessProbe

### DIFF
--- a/replicated-load-balanced/dictionary-deploy.yaml
+++ b/replicated-load-balanced/dictionary-deploy.yaml
@@ -16,7 +16,7 @@ spec:
         - containerPort: 8080
         readinessProbe:
           httpGet:
-            path: /ready
+            path: /readyz
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5


### PR DESCRIPTION
`/ready` is a valid dictionary entry, where `/readyz` is the correct path to the readiness probe for the _dictionary-server_ deployment.